### PR TITLE
feat: Implementados diario físico y mental

### DIFF
--- a/backend/diary_entries/models.py
+++ b/backend/diary_entries/models.py
@@ -8,7 +8,7 @@ class State(models.TextChoices):
     BAD = "B", _("Bad"),
     FAIR = "F", _("Fair"),
     GOOD = "G", _("Good"),
-    VERY_GOOD = "VG", _("Very Good"),
+    VERY_GOOD = "VG", _("Very good"),
 
 class BodyParts(models.TextChoices):
     HEAD = "HEAD", _("Head"),
@@ -16,59 +16,42 @@ class BodyParts(models.TextChoices):
     LEFT_ARM = "LEFT_ARM", _("Left arm"),
     RIGHT_ARM = "RIGHT_ARM", _("Right arm"),
     LEFT_LEG = "LEFT_LEG", _("Left leg"),
-    RIGHT_LEG = "RIGHT_LEG", _("Right leg")
+    RIGHT_LEG = "RIGHT_LEG", _("Right leg"),
 
 class Sleep(models.TextChoices):
     NONE = "NONE", _("No sleep"),
     LIGHT = "LIGHT", _("Light sleep"),
-    DEEP = "DEEP", _("Deep sleep")
+    DEEP = "DEEP", _("Deep sleep"),
 
 class Food(models.TextChoices):
     NONE = "NONE", _("Did not eat"),
     FAST = "FAST", _("Fast food"),
-    HEALTHY = "HEALTHY", _("Healthy food")
+    HEALTHY = "HEALTHY", _("Healthy food"),
 
 class Weather(models.TextChoices):
     SUNNY = "SUNNY", _("Sunny"),
     CLOUDY = "CLOUDY", _("Cloudy"),
     RAINY = "RAINY", _("Rainy"),
     SNOWY = "SNOWY", _("Snowy"),
-    THUNDER = "THUNDER", _("Thunder")
+    STORMY = "STORMY", _("STORMY"),
 
 
 class DiaryEntry(models.Model):
     state = models.CharField(choices=State.choices, max_length=15)
-    notes = models.TextField(max_length=500)
+    notes = models.TextField(max_length=1024)
     date = models.DateField()
 
     def __str__(self):
         return str(self.state) + " " + str(self.date)
 
 
-class BodyPart(models.Model):
-    name = models.CharField(choices=BodyParts.choices, primary_key=True, max_length=15)
-    
- 
 class PhysicalEntry(DiaryEntry):
-    body_parts = models.ManyToManyField(BodyPart) #, validators=[validate_unique_body_parts])
+    body_parts = models.TextField(max_length=1024, default="none") #, validators=[validate_unique_body_parts])
 
 
 class MentalEntry(DiaryEntry):
-    sleep = models.CharField(choices=Sleep.choices, max_length=15)
-    food = models.CharField(choices=Food.choices, max_length=15)
-    weather = models.CharField(choices=Weather.choices, max_length=15)
-    positive_thoughts = models.TextField(max_length=500)
-    negative_thoughts = models.TextField(max_length=500)
-
-
-'''
-def validate_unique_body_parts(value):
-    """
-    Validator function to ensure that only one value of each ranking type is allowed.
-    """
-    bparts = set()
-    for bpart in value:
-        if bpart in bparts:
-            raise ValidationError(f"Selección duplicada: {bpart}")
-        bparts.add(bpart)
-'''
+    sleep = models.CharField(choices=Sleep.choices, max_length=64)
+    food = models.CharField(choices=Food.choices, max_length=64)
+    weather = models.CharField(choices=Weather.choices, max_length=64)
+    positive_thoughts = models.TextField(max_length=1024)
+    negative_thoughts = models.TextField(max_length=1024)

--- a/backend/diary_entries/models.py
+++ b/backend/diary_entries/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from enum import Enum
 from django.utils.translation import gettext_lazy as _
+from users.models import Patient
 
 
 class State(models.TextChoices):
@@ -40,6 +41,7 @@ class DiaryEntry(models.Model):
     state = models.CharField(choices=State.choices, max_length=15)
     notes = models.TextField(max_length=1024)
     date = models.DateField()
+    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
 
     def __str__(self):
         return str(self.state) + " " + str(self.date)

--- a/backend/diary_entries/serializer.py
+++ b/backend/diary_entries/serializer.py
@@ -1,15 +1,67 @@
+from django.forms import ValidationError
 from rest_framework import serializers
 from diary_entries.models import PhysicalEntry, MentalEntry
+from django.contrib.auth.models import User
+
+
+
+class CreateSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    date = serializers.DateField()
+    state = serializers.CharField(max_length=64)
+    notes = serializers.CharField(max_length=1024)
+    
 
 class PhysicalEntrySerializer(serializers.ModelSerializer):
-    body_parts = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    body_parts = serializers.CharField(max_length=1024)
 
     class Meta:
         model = PhysicalEntry
-        fields = "__all__"
+        fields = ['id', 'date', 'state', 'body_parts', 'notes']
+
+
+    def validate_body_parts(self, value):
+        accepted_values = {"HEAD", "TORSO", "LEFT_ARM", "RIGHT_ARM", "LEFT_LEG", "RIGHT_LEG"}
+        already_used_values = []
+        splitted = value.split(",")
+        for part in splitted:
+            if (part.strip() in accepted_values and part.strip() not in already_used_values):
+                already_used_values.append(part.strip())
+            elif (part.strip() in accepted_values and part.strip() in already_used_values):
+                raise ValidationError("Recuerda no repetir partes del cuerpo")
+            else:
+                raise ValidationError("Elige partes del cuerpo válidas (HEAD, TORSO, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG)")
+        return value
 
 
 class MentalEntrySerializer(serializers.ModelSerializer):
+
+    weather = serializers.CharField(max_length=64)
+    food = serializers.CharField(max_length=64)
+    sleep = serializers.CharField(max_length=64)
+    positive_thoughts = serializers.CharField(max_length=1024)
+    negative_thoughts = serializers.CharField(max_length=1024)
     class Meta:
         model = MentalEntry
-        fields = "__all__"
+        fields = ['id', 'date', 'state', 'notes', 'weather', 'food', 'sleep', 'positive_thoughts', 'negative_thoughts']
+
+    def validate_weather(self, value):
+        accepted_values = {"SNOWY", "RAINY", "CLOUDY", "STORMY", "SUNNY"}
+        if value in accepted_values:
+            return value
+        else:
+            raise ValidationError("Elige un tiempo atmosférico válido (SNOWY, RAINY, CLOUDY, STORMY, SUNNY)")
+
+    def validate_food(self, value):
+        accepted_values = {"NONE", "FAST", "HEALTHY"}
+        if value in accepted_values:
+            return value
+        else:
+            raise ValidationError("Elige un tipo de comida válido (NONE, FAST, HEALTHY)")
+        
+    def validate_sleep(self, value):
+        accepted_values = {"NONE", "LIGHT", "DEEP"}
+        if value in accepted_values:
+            return value
+        else:
+            raise ValidationError("Elige una cantidad de sueño válida (NONE, LIGHT, DEEP)")

--- a/backend/diary_entries/serializer.py
+++ b/backend/diary_entries/serializer.py
@@ -4,20 +4,13 @@ from diary_entries.models import PhysicalEntry, MentalEntry
 from django.contrib.auth.models import User
 
 
-
-class CreateSerializer(serializers.Serializer):
-    id = serializers.IntegerField(read_only=True)
-    date = serializers.DateField()
-    state = serializers.CharField(max_length=64)
-    notes = serializers.CharField(max_length=1024)
-    
-
 class PhysicalEntrySerializer(serializers.ModelSerializer):
     body_parts = serializers.CharField(max_length=1024)
+    patient_id=serializers.IntegerField()
 
     class Meta:
         model = PhysicalEntry
-        fields = ['id', 'date', 'state', 'body_parts', 'notes']
+        fields = ['id', 'date', 'state', 'body_parts', 'notes', "patient_id"]
 
 
     def validate_body_parts(self, value):
@@ -41,9 +34,10 @@ class MentalEntrySerializer(serializers.ModelSerializer):
     sleep = serializers.CharField(max_length=64)
     positive_thoughts = serializers.CharField(max_length=1024)
     negative_thoughts = serializers.CharField(max_length=1024)
+    patient_id=serializers.IntegerField()
     class Meta:
         model = MentalEntry
-        fields = ['id', 'date', 'state', 'notes', 'weather', 'food', 'sleep', 'positive_thoughts', 'negative_thoughts']
+        fields = ['id', 'date', 'state', 'notes', 'weather', 'food', 'sleep', 'positive_thoughts', 'negative_thoughts', "patient_id"]
 
     def validate_weather(self, value):
         accepted_values = {"SNOWY", "RAINY", "CLOUDY", "STORMY", "SUNNY"}

--- a/backend/diary_entries/tests.py
+++ b/backend/diary_entries/tests.py
@@ -1,3 +1,368 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase, APIClient
+from rest_framework.views import status
+from diary_entries.models import PhysicalEntry, MentalEntry
+from diary_entries.serializer import MentalEntrySerializer, PhysicalEntrySerializer
+from rest_framework.test import APIRequestFactory
+from rest_framework.test import force_authenticate
+from diary_entries.views import PhysicalEntryList, MentalEntryList, PhysicalEntryCreate, MentalEntryCreate, PhysicalEntryId, MentalEntryId
+from django.urls import reverse
 
-# Create your tests here.
+
+class PhysicalEntryListTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+        
+        physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
+        physical_entry2 = PhysicalEntry.objects.create(date = "2022-06-29", state = "VB", body_parts = "TORSO", notes = "sit amet")
+        physical_entry1.save()
+        physical_entry2.save()
+
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = PhysicalEntryList.as_view()
+
+    def test_get_all_physical_entries(self):
+        request = self.factory.get('/diary_entries/physical_entry/list')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        p_entries = PhysicalEntry.objects.all()
+        serializer = PhysicalEntrySerializer(p_entries, many=True)
+        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+class MentalEntryListTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+        
+        mental_entry1 = MentalEntry.objects.create(date = "2023-01-29", state = "VG", weather = "STORMY", food = "FAST", sleep = "LIGHT", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        mental_entry2 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        mental_entry1.save()
+        mental_entry2.save()
+        
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = MentalEntryList.as_view()
+
+    def test_get_all_mental_entries(self):
+        request = self.factory.get('diary_entries/mental_entry/list')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        m_entries = MentalEntry.objects.all()
+        serializer = MentalEntrySerializer(m_entries, many=True)
+        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class PhysicalEntryCreateTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+
+        physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
+        physical_entry1.save()
+
+        self.correct_entry_data = {
+            "date": "2023-01-30",
+            "state": "G",
+            "body_parts": "TORSO",
+            "notes": "good day"
+        }
+
+        self.correct_entry_data_multiple_body_parts = {
+            "date": "2023-01-30",
+            "state": "G",
+            "body_parts": "TORSO, HEAD",
+            "notes": "good day"
+        }
+
+        self.repeated_body_part_data = {
+            "date": "2023-01-30",
+            "state": "G",
+            "body_parts": "TORSO, TORSO",
+            "notes": "good day"
+        }
+
+        self.incorrect_body_part_data = {
+            "date": "2023-01-30",
+            "state": "G",
+            "body_parts": "torso",
+            "notes": "good day"
+        }
+
+        self.incorrect_state_data = {
+            "date": "2023-01-30",
+            "state": "GDay",
+            "body_parts": "torso",
+            "notes": "good day"
+        }
+
+        self.incorrect_date_format = {
+            "date": "30-10-2021",
+            "state": "G",
+            "body_parts": "torso",
+            "notes": "good day"
+        }
+
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = PhysicalEntryCreate.as_view()
+
+    def test_create_correct_physical_entry(self):
+        # create user
+        request = self.factory.post('/diary_entries/physical_entry', self.correct_entry_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.correct_entry_data)
+
+    def test_create_correct_physical_entry_multiple_body_parts(self):
+        # create user
+        request = self.factory.post('/diary_entries/physical_entry', self.correct_entry_data_multiple_body_parts, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.correct_entry_data_multiple_body_parts)
+
+    def test_create_wrong(self):
+        request = self.factory.post('/diary_entries/physical_entry', {}, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_repeated_body_part(self):
+        request = self.factory.post('/diary_entries/physical_entry', self.repeated_body_part_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["body_parts"][0],"Recuerda no repetir partes del cuerpo")
+
+    def test_create_incorrect_body_part(self):
+        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_body_part_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["body_parts"][0],"Elige partes del cuerpo válidas (HEAD, TORSO, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG)")
+
+    def test_create_incorrect_state(self):
+        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_state_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+##        self.assertEqual(response.data["state"][0],'\"GDay\"no es una elección válida.')
+
+    def test_create_incorrect_date_format(self):
+        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_date_format, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["date"][0],"Fecha con formato erróneo. Use uno de los siguientes formatos en su lugar: YYYY-MM-DD.")
+
+class MentalEntryCreateTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+
+        mental_entry1 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        mental_entry1.save()
+
+        self.correct_data = {
+            "date": "2022-07-31",
+            "state": "VB",
+            "weather": "SUNNY",
+            "food": "HEALTHY",
+            "sleep": "LIGHT",
+            "positive_thoughts": "im doing very well at math",
+            "negative_thoughts": "this is taking far too long",
+            "notes": "im sad and tired"
+        }
+
+        self.incorrect_weather_data = {
+            "date": "2022-07-31",
+            "state": "VB",
+            "weather": "SUNNi",
+            "food": "HEALTHY",
+            "sleep": "LIGHT",
+            "positive_thoughts": "im doing very well at math",
+            "negative_thoughts": "this is taking far too long",
+            "notes": "im sad and tired"
+        }
+
+        self.incorrect_food_data = {
+            "date": "2022-07-31",
+            "state": "VB",
+            "weather": "SUNNY",
+            "food": "HEALTHi",
+            "sleep": "LIGHT",
+            "positive_thoughts": "im doing very well at math",
+            "negative_thoughts": "this is taking far too long",
+            "notes": "im sad and tired"
+        }
+
+        self.incorrect_sleep_data = {
+            "date": "2022-07-31",
+            "state": "VB",
+            "weather": "SUNNY",
+            "food": "HEALTHY",
+            "sleep": "LIGHt",
+            "positive_thoughts": "im doing very well at math",
+            "negative_thoughts": "this is taking far too long",
+            "notes": "im sad and tired"
+        }
+
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = MentalEntryCreate.as_view()
+
+    def test_create_correct_data(self):
+        request = self.factory.post('/diary_entry/mental_entry/', self.correct_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.correct_data)
+
+    def test_create_wrong_data(self):
+        request = self.factory.post('/diary_entry/mental_entry/', {}, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_incorrect_weather_data(self):
+        request = self.factory.post('/diary_entry/mental_entry/', self.incorrect_weather_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["weather"][0],"Elige un tiempo atmosférico válido (SNOWY, RAINY, CLOUDY, STORMY, SUNNY)")
+
+    def test_create_incorrect_food_data(self):
+        request = self.factory.post('/diary_entry/mental_entry/', self.incorrect_food_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["food"][0],"Elige un tipo de comida válido (NONE, FAST, HEALTHY)")  
+
+    def test_create_sleep_data(self):
+        request = self.factory.post('/diary_entry/mental_entry/', self.incorrect_sleep_data, format='json')
+        force_authenticate(request, self.admin)
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["sleep"][0],"Elige una cantidad de sueño válida (NONE, LIGHT, DEEP)")  
+
+class PhysicalEntryIdTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+
+        self.physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
+        self.physical_entry1.save()
+
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = PhysicalEntryId.as_view()
+
+
+    def test_get_valid_physical_entry(self):
+        request = self.factory.get(reverse("id_physical_entry", kwargs={"pk":self.physical_entry1.id}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=self.physical_entry1.id)
+
+        serializer = PhysicalEntrySerializer(self.physical_entry1)
+        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+    def test_delete_valid_physical_entry(self):
+        request = self.factory.delete(reverse("id_physical_entry", kwargs={"pk":self.physical_entry1.id}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=self.physical_entry1.id)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        
+class MentalEntryIdTest(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create(username="admin", email="admin@email.com", first_name="admin", last_name="admin")
+        self.admin.set_password("passAdmin")
+        self.admin.is_superuser = True
+        self.admin.save()
+
+        self.mental_entry1 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        self.mental_entry1.save()
+
+        #Establecer factory (siempre igual) y vista a testear
+        self.factory = APIRequestFactory()
+        self.view = MentalEntryId.as_view()
+
+
+    def test_get_valid_mental_entry(self):
+        request = self.factory.get(reverse("id_mental_entry", kwargs={"pk":self.mental_entry1.id}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=self.mental_entry1.id)
+
+        serializer = MentalEntrySerializer(self.mental_entry1)
+        self.assertEqual(response.data, serializer.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+    def test_delete_valid_mental_entry(self):
+        request = self.factory.delete(reverse("id_mental_entry", kwargs={"pk":self.mental_entry1.id}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=self.mental_entry1.id)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+'''
+    def test_get_invalid_physical_entry(self):
+        request = self.factory.get(reverse("id_physical_entry", kwargs={"pk":123123123123}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=123123123123)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_invalid_physical_entry(self):
+        request = self.factory.delete(reverse("id_physical_entry", kwargs={"pk":123123123123}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=123123123123)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_invalid_mental_entry(self):
+        request = self.factory.get(reverse("id_mental_entry", kwargs={"pk":123123123123}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=123123123123)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_invalid_mental_entry(self):
+        request = self.factory.delete(reverse("id_mental_entry", kwargs={"pk":123123123123}))
+        force_authenticate(request, self.admin)
+        response = self.view(request, pk=123123123123)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+'''

--- a/backend/diary_entries/tests.py
+++ b/backend/diary_entries/tests.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIRequestFactory
 from rest_framework.test import force_authenticate
 from diary_entries.views import PhysicalEntryList, MentalEntryList, PhysicalEntryCreate, MentalEntryCreate, PhysicalEntryId, MentalEntryId
 from django.urls import reverse
+from users.models import Patient
 
 
 class PhysicalEntryListTest(APITestCase):
@@ -15,9 +16,16 @@ class PhysicalEntryListTest(APITestCase):
         self.admin.set_password("passAdmin")
         self.admin.is_superuser = True
         self.admin.save()
+
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
         
-        physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
-        physical_entry2 = PhysicalEntry.objects.create(date = "2022-06-29", state = "VB", body_parts = "TORSO", notes = "sit amet")
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
+        
+        physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor", patient = patient1)
+        physical_entry2 = PhysicalEntry.objects.create(date = "2022-06-29", state = "VB", body_parts = "TORSO", notes = "sit amet", patient = patient1)
         physical_entry1.save()
         physical_entry2.save()
 
@@ -26,7 +34,7 @@ class PhysicalEntryListTest(APITestCase):
         self.view = PhysicalEntryList.as_view()
 
     def test_get_all_physical_entries(self):
-        request = self.factory.get('/diary_entries/physical_entry/list')
+        request = self.factory.get('/diary_entries/physical_entry/list/')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -41,9 +49,16 @@ class MentalEntryListTest(APITestCase):
         self.admin.set_password("passAdmin")
         self.admin.is_superuser = True
         self.admin.save()
+
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
         
-        mental_entry1 = MentalEntry.objects.create(date = "2023-01-29", state = "VG", weather = "STORMY", food = "FAST", sleep = "LIGHT", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
-        mental_entry2 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
+        
+        mental_entry1 = MentalEntry.objects.create(date = "2023-01-29", state = "VG", weather = "STORMY", food = "FAST", sleep = "LIGHT", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet", patient = patient1)
+        mental_entry2 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet", patient = patient1)
         mental_entry1.save()
         mental_entry2.save()
         
@@ -52,7 +67,7 @@ class MentalEntryListTest(APITestCase):
         self.view = MentalEntryList.as_view()
 
     def test_get_all_mental_entries(self):
-        request = self.factory.get('diary_entries/mental_entry/list')
+        request = self.factory.get('diary_entries/mental_entry/list/')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -69,49 +84,59 @@ class PhysicalEntryCreateTest(APITestCase):
         self.admin.is_superuser = True
         self.admin.save()
 
-        physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
-        physical_entry1.save()
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
+        
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
 
         self.correct_entry_data = {
             "date": "2023-01-30",
             "state": "G",
             "body_parts": "TORSO",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         self.correct_entry_data_multiple_body_parts = {
             "date": "2023-01-30",
             "state": "G",
             "body_parts": "TORSO, HEAD",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         self.repeated_body_part_data = {
             "date": "2023-01-30",
             "state": "G",
             "body_parts": "TORSO, TORSO",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         self.incorrect_body_part_data = {
             "date": "2023-01-30",
             "state": "G",
             "body_parts": "torso",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         self.incorrect_state_data = {
             "date": "2023-01-30",
             "state": "GDay",
             "body_parts": "torso",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         self.incorrect_date_format = {
             "date": "30-10-2021",
             "state": "G",
             "body_parts": "torso",
-            "notes": "good day"
+            "notes": "good day",
+            "patient_id":patient1.id
         }
 
         #Establecer factory (siempre igual) y vista a testear
@@ -120,7 +145,7 @@ class PhysicalEntryCreateTest(APITestCase):
 
     def test_create_correct_physical_entry(self):
         # create user
-        request = self.factory.post('/diary_entries/physical_entry', self.correct_entry_data, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.correct_entry_data, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -129,7 +154,7 @@ class PhysicalEntryCreateTest(APITestCase):
 
     def test_create_correct_physical_entry_multiple_body_parts(self):
         # create user
-        request = self.factory.post('/diary_entries/physical_entry', self.correct_entry_data_multiple_body_parts, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.correct_entry_data_multiple_body_parts, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -137,14 +162,14 @@ class PhysicalEntryCreateTest(APITestCase):
         self.assertEqual(response.data, self.correct_entry_data_multiple_body_parts)
 
     def test_create_wrong(self):
-        request = self.factory.post('/diary_entries/physical_entry', {}, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', {}, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_repeated_body_part(self):
-        request = self.factory.post('/diary_entries/physical_entry', self.repeated_body_part_data, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.repeated_body_part_data, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -152,7 +177,7 @@ class PhysicalEntryCreateTest(APITestCase):
         self.assertEqual(response.data["body_parts"][0],"Recuerda no repetir partes del cuerpo")
 
     def test_create_incorrect_body_part(self):
-        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_body_part_data, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.incorrect_body_part_data, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -160,7 +185,7 @@ class PhysicalEntryCreateTest(APITestCase):
         self.assertEqual(response.data["body_parts"][0],"Elige partes del cuerpo válidas (HEAD, TORSO, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG)")
 
     def test_create_incorrect_state(self):
-        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_state_data, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.incorrect_state_data, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -168,7 +193,7 @@ class PhysicalEntryCreateTest(APITestCase):
 ##        self.assertEqual(response.data["state"][0],'\"GDay\"no es una elección válida.')
 
     def test_create_incorrect_date_format(self):
-        request = self.factory.post('/diary_entries/physical_entry', self.incorrect_date_format, format='json')
+        request = self.factory.post('/diary_entries/physical_entry/', self.incorrect_date_format, format='json')
         force_authenticate(request, self.admin)
         response = self.view(request)
 
@@ -182,8 +207,13 @@ class MentalEntryCreateTest(APITestCase):
         self.admin.is_superuser = True
         self.admin.save()
 
-        mental_entry1 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
-        mental_entry1.save()
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
+        
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
+
 
         self.correct_data = {
             "date": "2022-07-31",
@@ -193,7 +223,8 @@ class MentalEntryCreateTest(APITestCase):
             "sleep": "LIGHT",
             "positive_thoughts": "im doing very well at math",
             "negative_thoughts": "this is taking far too long",
-            "notes": "im sad and tired"
+            "notes": "im sad and tired",
+            "patient_id":patient1.id
         }
 
         self.incorrect_weather_data = {
@@ -204,7 +235,8 @@ class MentalEntryCreateTest(APITestCase):
             "sleep": "LIGHT",
             "positive_thoughts": "im doing very well at math",
             "negative_thoughts": "this is taking far too long",
-            "notes": "im sad and tired"
+            "notes": "im sad and tired",
+            "patient_id":patient1.id
         }
 
         self.incorrect_food_data = {
@@ -215,7 +247,8 @@ class MentalEntryCreateTest(APITestCase):
             "sleep": "LIGHT",
             "positive_thoughts": "im doing very well at math",
             "negative_thoughts": "this is taking far too long",
-            "notes": "im sad and tired"
+            "notes": "im sad and tired",
+            "patient_id":patient1.id
         }
 
         self.incorrect_sleep_data = {
@@ -226,7 +259,8 @@ class MentalEntryCreateTest(APITestCase):
             "sleep": "LIGHt",
             "positive_thoughts": "im doing very well at math",
             "negative_thoughts": "this is taking far too long",
-            "notes": "im sad and tired"
+            "notes": "im sad and tired",
+            "patient_id":patient1.id
         }
 
         #Establecer factory (siempre igual) y vista a testear
@@ -279,7 +313,15 @@ class PhysicalEntryIdTest(APITestCase):
         self.admin.is_superuser = True
         self.admin.save()
 
-        self.physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor")
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
+        
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
+        
+
+        self.physical_entry1 = PhysicalEntry.objects.create(date = "2023-01-29", state = "VG", body_parts = "HEAD", notes = "Lorem ipsum dolor", patient=patient1)
         self.physical_entry1.save()
 
         #Establecer factory (siempre igual) y vista a testear
@@ -311,7 +353,14 @@ class MentalEntryIdTest(APITestCase):
         self.admin.is_superuser = True
         self.admin.save()
 
-        self.mental_entry1 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet")
+        user1 = User.objects.create(username="user1", email="user1@email.com", first_name="nameUser1", last_name="lastUser1")
+        user1.set_password("passUser1")
+        user1.save()
+        
+        patient1 = Patient.objects.create(user=user1, tel='1234567890', birthdate='1990-01-01')
+        patient1.save()
+
+        self.mental_entry1 = MentalEntry.objects.create(date = "2022-06-29", state = "VB", weather = "SUNNY", food = "HEALTHY", sleep = "NONE", positive_thoughts = "lorem ipsum", negative_thoughts = "dolor sit", notes = "amet", patient=patient1)
         self.mental_entry1.save()
 
         #Establecer factory (siempre igual) y vista a testear

--- a/backend/diary_entries/urls.py
+++ b/backend/diary_entries/urls.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+from django.urls import path
+from diary_entries.views import MentalEntryList, MentalEntryId, MentalEntryCreate, PhysicalEntryList, PhysicalEntryId, PhysicalEntryCreate
+
+urlpatterns = [
+    path('mental_entry/list/', MentalEntryList.as_view()),
+    path('mental_entry', MentalEntryCreate.as_view()),
+    path('mental_entry/<int:pk>', MentalEntryId.as_view(), name="id_mental_entry"),
+    path('physical_entry/list', PhysicalEntryList.as_view()),
+    path('physical_entry', PhysicalEntryCreate.as_view()),
+    path('physical_entry/<int:pk>', PhysicalEntryId.as_view(), name="id_physical_entry"),
+]

--- a/backend/diary_entries/urls.py
+++ b/backend/diary_entries/urls.py
@@ -1,12 +1,14 @@
 from django.contrib import admin
 from django.urls import path
-from diary_entries.views import MentalEntryList, MentalEntryId, MentalEntryCreate, PhysicalEntryList, PhysicalEntryId, PhysicalEntryCreate
+from diary_entries.views import MentalEntryList, MentalEntryId, MentalEntryCreate, PhysicalEntryList, PhysicalEntryId, PhysicalEntryCreate, MentalEntryPatientList, PhysicalEntryPatientList
 
 urlpatterns = [
     path('mental_entry/list/', MentalEntryList.as_view()),
-    path('mental_entry', MentalEntryCreate.as_view()),
-    path('mental_entry/<int:pk>', MentalEntryId.as_view(), name="id_mental_entry"),
-    path('physical_entry/list', PhysicalEntryList.as_view()),
-    path('physical_entry', PhysicalEntryCreate.as_view()),
-    path('physical_entry/<int:pk>', PhysicalEntryId.as_view(), name="id_physical_entry"),
+    path('mental_entry/', MentalEntryCreate.as_view()),
+    path('mental_entry/<int:pk>/', MentalEntryId.as_view(), name="id_mental_entry"),
+    path('physical_entry/list/', PhysicalEntryList.as_view()),
+    path('physical_entry/', PhysicalEntryCreate.as_view()),
+    path('physical_entry/<int:pk>/', PhysicalEntryId.as_view(), name="id_physical_entry"),
+    path('mental_entry/patient/<int:pk>/', MentalEntryPatientList.as_view()),
+    path('physical_entry/patient/<int:pk>/', PhysicalEntryPatientList.as_view()),
 ]

--- a/backend/diary_entries/views.py
+++ b/backend/diary_entries/views.py
@@ -1,13 +1,30 @@
 from rest_framework.views import APIView
 from diary_entries.models import PhysicalEntry, MentalEntry
-from diary_entries.serializer import PhysicalEntrySerializer, MentalEntrySerializer, CreateSerializer
+from diary_entries.serializer import PhysicalEntrySerializer, MentalEntrySerializer
 from rest_framework.response import Response
 from rest_framework import status
+from django.shortcuts import get_object_or_404
+from users.models import Patient
 
 
 class MentalEntryList(APIView):
     def get(self, request):
         mental_entries = MentalEntry.objects.all()
+        serializer = MentalEntrySerializer(mental_entries, many=True)
+        return Response(serializer.data)
+    
+    def get_by_user(self, request, *args, **kwargs):
+        pk = self.kwargs.get('pk')
+        patient = get_object_or_404(Patient, id=pk)
+        mental_entries = MentalEntry.objects.filter(patient = patient)
+        serializer = MentalEntrySerializer(mental_entries, many=True)
+        return Response(serializer.data)
+
+class MentalEntryPatientList(APIView):
+    def get(self, request, *args, **kwargs):
+        pk = self.kwargs.get('pk')
+        patient = get_object_or_404(Patient, id=pk)
+        mental_entries = MentalEntry.objects.filter(patient = patient)
         serializer = MentalEntrySerializer(mental_entries, many=True)
         return Response(serializer.data)
 
@@ -24,9 +41,16 @@ class MentalEntryCreate(APIView):
             positive_thoughts = serializer.data["positive_thoughts"]
             negative_thoughts = serializer.data["negative_thoughts"]
             notes = serializer.data["notes"]
+            patient_id = serializer.data["patient_id"]
+
+            patient = get_object_or_404(Patient, id=patient_id)
+            patient_diary_entry_list = MentalEntry.objects.filter(patient = patient)
+            for entry in patient_diary_entry_list:
+                if(str(entry.date) == date):
+                    return Response({"error":"Ya existe una entrada de este tipo de diario en esta fecha para este usuario"}, status=status.HTTP_400_BAD_REQUEST)
 
             mental_entry = MentalEntry(date = date, state = state, weather = weather, food = food, sleep = sleep,
-                                      positive_thoughts = positive_thoughts, negative_thoughts = negative_thoughts, notes = notes)
+                                      positive_thoughts = positive_thoughts, negative_thoughts = negative_thoughts, notes = notes, patient = patient)
 
             mental_entry.save()
             
@@ -57,6 +81,14 @@ class PhysicalEntryList(APIView):
         physical_entry = PhysicalEntry.objects.all()
         serializer = PhysicalEntrySerializer(physical_entry, many=True)
         return Response(serializer.data)
+    
+class PhysicalEntryPatientList(APIView):
+    def get(self, request, *args, **kwargs):
+        pk = self.kwargs.get('pk')
+        patient = get_object_or_404(Patient, id=pk)
+        physical_entries = PhysicalEntry.objects.filter(patient = patient)
+        serializer = MentalEntrySerializer(physical_entries, many=True)
+        return Response(serializer.data)
 
 
 class PhysicalEntryCreate(APIView):
@@ -68,8 +100,15 @@ class PhysicalEntryCreate(APIView):
             state = serializer.data["state"]
             body_parts = serializer.data["body_parts"]
             notes = serializer.data["notes"]
+            patient_id = serializer.data["patient_id"]
 
-            physical_entry = PhysicalEntry(date = date, state = state, body_parts = body_parts, notes = notes)
+            patient = get_object_or_404(Patient, id=patient_id)
+            patient_diary_entry_list = PhysicalEntry.objects.filter(patient = patient)
+            for entry in patient_diary_entry_list:
+                if(str(entry.date) == date):
+                    return Response({"error":"Ya existe una entrada de este tipo de diario en esta fecha para este usuario"}, status=status.HTTP_400_BAD_REQUEST)
+
+            physical_entry = PhysicalEntry(date = date, state = state, body_parts = body_parts, notes = notes, patient = patient)
 
             physical_entry.save()
 

--- a/backend/diary_entries/views.py
+++ b/backend/diary_entries/views.py
@@ -1,3 +1,96 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from diary_entries.models import PhysicalEntry, MentalEntry
+from diary_entries.serializer import PhysicalEntrySerializer, MentalEntrySerializer, CreateSerializer
+from rest_framework.response import Response
+from rest_framework import status
 
-# Create your views here.
+
+class MentalEntryList(APIView):
+    def get(self, request):
+        mental_entries = MentalEntry.objects.all()
+        serializer = MentalEntrySerializer(mental_entries, many=True)
+        return Response(serializer.data)
+
+class MentalEntryCreate(APIView):
+    def post(self, request):
+        serializer = MentalEntrySerializer(data = request.data)
+        
+        if(serializer.is_valid() and serializer.is_valid()):
+            date = serializer.data["date"]
+            state = serializer.data["state"]
+            weather = serializer.data["weather"]
+            food = serializer.data["food"]
+            sleep = serializer.data["sleep"]
+            positive_thoughts = serializer.data["positive_thoughts"]
+            negative_thoughts = serializer.data["negative_thoughts"]
+            notes = serializer.data["notes"]
+
+            mental_entry = MentalEntry(date = date, state = state, weather = weather, food = food, sleep = sleep,
+                                      positive_thoughts = positive_thoughts, negative_thoughts = negative_thoughts, notes = notes)
+
+            mental_entry.save()
+            
+            return Response(serializer.data)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+
+class MentalEntryId(APIView):
+    def get_mental_entry_by_pk(self, pk):
+        try:
+            return MentalEntry.objects.get(id=pk)
+        except(AttributeError):
+            return Response({"error":"Esa entrada de diario mental no existe"}, status=status.HTTP_404_NOT_FOUND)
+    
+    def get(self, request, pk):
+        mental_entry = self.get_mental_entry_by_pk(pk)
+        serializer = MentalEntrySerializer(mental_entry)
+        return Response(serializer.data)
+    
+    def delete(self, request, pk):
+        mental_entry = self.get_mental_entry_by_pk(pk)
+        mental_entry.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class PhysicalEntryList(APIView):
+    def get(self, request):
+        physical_entry = PhysicalEntry.objects.all()
+        serializer = PhysicalEntrySerializer(physical_entry, many=True)
+        return Response(serializer.data)
+
+
+class PhysicalEntryCreate(APIView):
+    def post(self, request):
+        serializer = PhysicalEntrySerializer(data = request.data)
+        
+        if (serializer.is_valid()):
+            date = serializer.data["date"]
+            state = serializer.data["state"]
+            body_parts = serializer.data["body_parts"]
+            notes = serializer.data["notes"]
+
+            physical_entry = PhysicalEntry(date = date, state = state, body_parts = body_parts, notes = notes)
+
+            physical_entry.save()
+
+            return Response(serializer.data)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        
+
+class PhysicalEntryId(APIView):
+    def get_physical_entry_by_pk(self, pk):
+        try:
+            return PhysicalEntry.objects.get(id=pk)
+        except(AttributeError):
+            return Response({"error":"Esa entrada de diario físico no existe"}, status=status.HTTP_404_NOT_FOUND)
+    
+    def get(self, request, pk):
+        physical_entry = self.get_physical_entry_by_pk(pk)
+        serializer = PhysicalEntrySerializer(physical_entry)
+        return Response(serializer.data)
+    
+    def delete(self, request, pk):
+        physical_entry = self.get_physical_entry_by_pk(pk)
+        physical_entry.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -39,6 +39,6 @@ urlpatterns = [
     #path("appointments/", include("appointments.urls")),
     path("users/", include("users.urls")),
     #path("metrics/", include("metrics.urls")),
-    #path("diary_entries/", include("diary_entries.urls")),
+    path("diary_entries/", include("diary_entries.urls")),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]


### PR DESCRIPTION
Esta pr trae tanto el diario físico como el mental, un ejemplo para la creación correcta de una entrada física es el siguiente json:

{
	"date": "2023-01-29",
	"state": "VG",
        "body_parts": "HEAD, TORSO",
	"notes": "Lorem ipsum dolor sit amet"
}

y para el mental esta:

{
	"date":  "2023-02-10",
	"state": "VG",
	"weather": "RAINY",
	"food": "FAST",
	"sleep": "DEEP",
	"positive_thoughts": "I thought bout getting a nice mini",
	"negative_thoughts": "Its expensive so i shouldnt buy it ;(",
	"notes": "Lorem ipsum dolor sit amet"
}